### PR TITLE
Added move selection to improve type coverage chart

### DIFF
--- a/components/analysis/CoverageMatrix.tsx
+++ b/components/analysis/CoverageMatrix.tsx
@@ -1,11 +1,91 @@
 "use client";
 
+import {
+  Combobox,
+  ComboboxInput,
+  ComboboxOption,
+  ComboboxOptions,
+} from "@headlessui/react";
 import Image from "next/image";
+import { useMemo, useState } from "react";
+import { TypePill } from "@/components/ui/TypePill";
 import { multiplierColor, multiplierLabel } from "@/lib/theme";
 import { useAnalysis } from "@/hooks/useAnalysis";
+import { useAppStore } from "@/stores/appStore";
+import type { PokemonMove } from "@/lib/types";
+
+function MoveCombobox({
+  slotLabel,
+  selectedName,
+  moves,
+  onSelect,
+}: {
+  slotLabel: string;
+  selectedName: string | null;
+  moves: PokemonMove[];
+  onSelect: (moveName: string | null) => void;
+}) {
+  const [query, setQuery] = useState("");
+  const selectedMove =
+    moves.find((move) => move.name.toLowerCase() === selectedName?.toLowerCase()) ??
+    null;
+  const filteredMoves = useMemo(() => {
+    const needle = query.trim().toLowerCase();
+    if (!needle) return moves;
+    return moves.filter((move) => move.name.toLowerCase().includes(needle));
+  }, [moves, query]);
+
+  return (
+    <Combobox
+      value={selectedMove}
+      onChange={(move: PokemonMove | null) => {
+        onSelect(move?.name ?? null);
+        setQuery("");
+      }}
+      nullable
+    >
+      <div className="relative">
+        <div className="flex items-center gap-1 rounded border border-border bg-bg px-1.5 py-1 text-[10px]">
+          <span className="font-mono text-muted">{slotLabel}</span>
+          <ComboboxInput
+            aria-label={`${slotLabel} move search`}
+            className="min-w-0 flex-1 bg-transparent text-[10px] outline-none"
+            placeholder="Search move..."
+            displayValue={(move: PokemonMove | null) => move?.name ?? ""}
+            onChange={(event) => setQuery(event.target.value)}
+            onBlur={() => setQuery("")}
+          />
+        </div>
+        <ComboboxOptions className="absolute z-30 mt-1 max-h-48 w-full overflow-auto rounded border border-border bg-surface shadow-lg text-[10px]">
+          <ComboboxOption
+            value={null}
+            className="cursor-pointer px-2 py-1 text-muted data-[focus]:bg-surface-2"
+          >
+            Clear selection
+          </ComboboxOption>
+          {filteredMoves.map((move) => (
+            <ComboboxOption
+              key={move.name}
+              value={move}
+              className="cursor-pointer px-2 py-1 data-[focus]:bg-surface-2"
+            >
+              {move.name} ({move.type}, {move.damageClass})
+            </ComboboxOption>
+          ))}
+          {filteredMoves.length === 0 && (
+            <li className="px-2 py-1 text-muted">No moves found.</li>
+          )}
+        </ComboboxOptions>
+      </div>
+    </Combobox>
+  );
+}
 
 export function CoverageMatrix() {
   const { matrix, mine, opps } = useAnalysis();
+  const myMovesets = useAppStore((s) => s.myMovesets);
+  const setMyMovesetMove = useAppStore((s) => s.setMyMovesetMove);
+  const clearMyMoveset = useAppStore((s) => s.clearMyMoveset);
   if (mine.length === 0 || opps.length === 0) {
     return (
       <div className="rounded-lg border border-border bg-surface p-4 text-sm text-muted">
@@ -18,9 +98,96 @@ export function CoverageMatrix() {
       <div className="flex items-center justify-between mb-2">
         <h3 className="text-sm font-semibold">Coverage matrix</h3>
         <span className="font-mono text-[10px] text-muted">
-          offense / defense per pairing
+          selected moves offense / incoming defense
         </span>
       </div>
+      <section className="mb-3 rounded border border-border bg-surface-2/40 p-2">
+        <h4 className="text-[11px] uppercase tracking-wide text-muted mb-2">
+          My selected moves (4 per Pokémon)
+        </h4>
+        <div className="grid gap-2">
+          {mine.map((m) => {
+            const slotIndex = m.slotIndex ?? -1;
+            const selected =
+              slotIndex >= 0
+                ? myMovesets[slotIndex] ?? [null, null, null, null]
+                : [null, null, null, null];
+            const selectedMoves = selected
+              .map((moveName) =>
+                moveName
+                  ? m.pokemon.moves.find(
+                      (move) => move.name.toLowerCase() === moveName.toLowerCase(),
+                    )
+                  : undefined,
+              )
+              .filter((move): move is (typeof m.pokemon.moves)[number] => !!move);
+            const offensiveTypes = Array.from(
+              new Set(
+                selectedMoves
+                  .filter((move) => move.damageClass !== "status")
+                  .map((move) => move.type),
+              ),
+            );
+            return (
+              <div
+                key={`${m.pokemon.slug}-${slotIndex}`}
+                className="rounded border border-border bg-surface px-2 py-1.5"
+              >
+                <div className="flex items-center gap-2">
+                  <Image
+                    src={m.pokemon.spriteUrl}
+                    alt={m.pokemon.name}
+                    width={24}
+                    height={24}
+                    className="h-6 w-6 [image-rendering:pixelated]"
+                    unoptimized
+                  />
+                  <span className="text-xs font-medium">{m.pokemon.name}</span>
+                  <button
+                    type="button"
+                    onClick={() => clearMyMoveset(slotIndex)}
+                    className="ml-auto text-[10px] text-muted hover:text-danger"
+                  >
+                    Clear
+                  </button>
+                </div>
+                <div className="mt-1 grid grid-cols-2 md:grid-cols-4 gap-1">
+                  {Array.from({ length: 4 }, (_, moveIdx) => (
+                    <div
+                      key={moveIdx}
+                      className="min-w-0"
+                    >
+                      <MoveCombobox
+                        slotLabel={`M${moveIdx + 1}`}
+                        selectedName={selected[moveIdx]}
+                        moves={m.pokemon.moves}
+                        onSelect={(moveName) =>
+                          setMyMovesetMove(slotIndex, moveIdx, moveName)
+                        }
+                      />
+                    </div>
+                  ))}
+                </div>
+                <div className="mt-1 flex flex-wrap gap-1 min-h-4">
+                  {offensiveTypes.map((t, idx) => (
+                    <TypePill key={`${t}-${idx}`} type={t} size="xs" />
+                  ))}
+                  {selectedMoves.length > 0 && offensiveTypes.length === 0 && (
+                    <span className="text-[10px] text-muted">
+                      Only status moves selected; no offensive coverage applied.
+                    </span>
+                  )}
+                  {selectedMoves.length === 0 && (
+                    <span className="text-[10px] text-muted">
+                      No moves selected - using usage/STAB fallback.
+                    </span>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </section>
       <div className="overflow-x-auto">
         <table className="border-separate border-spacing-1">
           <thead>

--- a/components/team/PokemonSearch.tsx
+++ b/components/team/PokemonSearch.tsx
@@ -72,6 +72,7 @@ export function PokemonSearch({
         slug: item.slug,
         types: [],
         spriteUrl: spriteUrl(item.id),
+        moves: [],
       });
       setQ("");
       setOpen(false);

--- a/hooks/useAnalysis.ts
+++ b/hooks/useAnalysis.ts
@@ -15,6 +15,7 @@ import { useAppStore } from "@/stores/appStore";
 function toContexts(
   pool: ReturnType<typeof useAppStore.getState>["myPool"],
   battle: number[],
+  myMovesets: ReturnType<typeof useAppStore.getState>["myMovesets"] | null,
   usageCache: Map<string, import("@/lib/types").UsageData>,
   format: string,
 ): MonContext[] {
@@ -24,10 +25,20 @@ function toContexts(
   return indices
     .map((i) => pool[i])
     .filter((p): p is NonNullable<typeof p> => !!p)
-    .map((p) => ({
-      pokemon: p,
-      usage: usageCache.get(`${format}:${p.slug}`) ?? null,
-    }));
+    .map((p, idx) => {
+      const slotIndex = indices[idx];
+      const chosenMoves = (myMovesets?.[slotIndex] ?? [])
+        .map((moveName) =>
+          p.moves.find((move) => move.name.toLowerCase() === moveName?.toLowerCase()),
+        )
+        .filter((move): move is import("@/lib/types").PokemonMove => !!move);
+      return {
+        pokemon: p,
+        usage: usageCache.get(`${format}:${p.slug}`) ?? null,
+        selectedMoves: chosenMoves,
+        slotIndex,
+      };
+    });
 }
 
 export function useAnalysis() {
@@ -35,12 +46,13 @@ export function useAnalysis() {
   const oppPool = useAppStore((s) => s.oppPool);
   const myBattle = useAppStore((s) => s.myBattle);
   const oppBattle = useAppStore((s) => s.oppBattle);
+  const myMovesets = useAppStore((s) => s.myMovesets);
   const usageCache = useAppStore((s) => s.usageCache);
   const format = useAppStore((s) => s.format);
 
   return useMemo(() => {
-    const mine = toContexts(myPool, myBattle, usageCache, format);
-    const opps = toContexts(oppPool, oppBattle, usageCache, format);
+    const mine = toContexts(myPool, myBattle, myMovesets, usageCache, format);
+    const opps = toContexts(oppPool, oppBattle, null, usageCache, format);
     return {
       mine,
       opps,
@@ -51,5 +63,5 @@ export function useAnalysis() {
       defense: defensiveScore(mine, opps),
       teamScore: compositeTeamScore(mine, opps),
     };
-  }, [myPool, oppPool, myBattle, oppBattle, usageCache, format]);
+  }, [myPool, oppPool, myBattle, oppBattle, myMovesets, usageCache, format]);
 }

--- a/lib/analysis.ts
+++ b/lib/analysis.ts
@@ -1,4 +1,4 @@
-import type { Pokemon, TypeName, UsageData } from "./types";
+import type { Pokemon, PokemonMove, TypeName, UsageData } from "./types";
 import { ALL_TYPES } from "./types";
 import {
   effectiveness,
@@ -9,9 +9,19 @@ import {
 export interface MonContext {
   pokemon: Pokemon;
   usage?: UsageData | null;
+  selectedMoves?: PokemonMove[];
+  slotIndex?: number;
 }
 
 export function attackingTypes(ctx: MonContext): TypeName[] {
+  if (ctx.selectedMoves && ctx.selectedMoves.length > 0) {
+    const fromMoves = ctx.selectedMoves
+      .filter((m) => m.damageClass !== "status")
+      .map((m) => m.type);
+    if (fromMoves.length > 0) {
+      return Array.from(new Set(fromMoves));
+    }
+  }
   const fromUsage = ctx.usage?.topMoves
     .map((m) => m.type)
     .filter((t): t is TypeName => !!t);

--- a/lib/pokeapi.ts
+++ b/lib/pokeapi.ts
@@ -1,9 +1,5 @@
-import type {
-  Pokemon,
-  PokemonData,
-  PokemonListItem,
-  TypeName,
-} from "./types";
+import { ALL_TYPES } from "./types";
+import type { Pokemon, PokemonData, PokemonListItem, PokemonMove, TypeName } from "./types";
 
 const BASE = "https://pokeapi.co/api/v2";
 const SPRITE_BASE =
@@ -62,6 +58,46 @@ interface DetailRaw {
       "official-artwork"?: { front_default: string | null };
     };
   };
+  moves: { move: { name: string; url: string } }[];
+}
+
+interface MoveDetailRaw {
+  type: { name: string };
+  damage_class: { name: string };
+}
+
+const moveCache = new Map<string, Promise<PokemonMove | null>>();
+
+async function fetchMoveDetail(
+  url: string,
+  signal?: AbortSignal,
+): Promise<PokemonMove | null> {
+  let inflight = moveCache.get(url);
+  if (!inflight) {
+    inflight = fetch(url, { signal, cache: "force-cache" })
+      .then(async (res) => {
+        if (!res.ok) return null;
+        const raw = (await res.json()) as MoveDetailRaw;
+        const type = raw.type?.name;
+        const damageClass = raw.damage_class?.name;
+        const validType = (ALL_TYPES as string[]).includes(type)
+          ? (type as TypeName)
+          : null;
+        if (!validType) return null;
+        if (!["physical", "special", "status"].includes(damageClass)) {
+          return null;
+        }
+        const parsedDamageClass = damageClass as PokemonMove["damageClass"];
+        return {
+          name: "",
+          type: validType,
+          damageClass: parsedDamageClass,
+        };
+      })
+      .catch(() => null);
+    moveCache.set(url, inflight);
+  }
+  return inflight;
 }
 
 export async function fetchPokemonDetail(
@@ -80,6 +116,22 @@ export async function fetchPokemonDetail(
   const stats = Object.fromEntries(
     raw.stats.map((s) => [s.stat.name, s.base_stat]),
   );
+  const uniqueMoveRows = Array.from(
+    new Map(raw.moves.map((m) => [m.move.name, m.move])).values(),
+  );
+  const moveDetails = await Promise.all(
+    uniqueMoveRows.map(async (row) => {
+      const detail = await fetchMoveDetail(row.url, signal);
+      if (!detail) return null;
+      return {
+        ...detail,
+        name: row.name,
+      } as PokemonMove;
+    }),
+  );
+  const moves = moveDetails
+    .filter((m): m is PokemonMove => !!m)
+    .sort((a, b) => a.name.localeCompare(b.name));
   return {
     id: raw.id,
     name: prettyName(raw.name),
@@ -97,6 +149,7 @@ export async function fetchPokemonDetail(
     abilities: raw.abilities.map((a) => a.ability.name),
     height: raw.height,
     weight: raw.weight,
+    moves,
   };
 }
 
@@ -107,5 +160,6 @@ export function toLightPokemon(data: PokemonData): Pokemon {
     slug: data.slug,
     types: data.types,
     spriteUrl: data.spriteUrl,
+    moves: data.moves,
   };
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -39,12 +39,21 @@ export const ALL_TYPES: TypeName[] = [
   "fairy",
 ];
 
+export type MoveDamageClass = "physical" | "special" | "status";
+
+export interface PokemonMove {
+  name: string;
+  type: TypeName;
+  damageClass: MoveDamageClass;
+}
+
 export interface Pokemon {
   id: number;
   name: string;
   slug: string;
   types: TypeName[];
   spriteUrl: string;
+  moves: PokemonMove[];
 }
 
 export interface BaseStats {
@@ -67,6 +76,7 @@ export interface UsageMove {
   name: string;
   pct: number;
   type?: TypeName;
+  isDamaging?: boolean;
 }
 
 export interface UsageEntry {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "pokemon-champions-drafter",
       "version": "0.1.0",
       "dependencies": {
+        "@headlessui/react": "^2.2.10",
         "clsx": "^2.1.1",
         "lucide-react": "^1.8.0",
         "next": "16.2.4",
@@ -424,6 +425,79 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/react": {
+      "version": "0.26.28",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.26.28.tgz",
+      "integrity": "sha512-yORQuuAtVpiRjpMhdc0wJj06b9JFjrYF4qp96j++v2NBpbi6SEGF7donUJ3TMieerQ6qVkAv1tgr7L4r5roTqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.1.2",
+        "@floating-ui/utils": "^0.2.8",
+        "tabbable": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.6"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
+    },
+    "node_modules/@headlessui/react": {
+      "version": "2.2.10",
+      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-2.2.10.tgz",
+      "integrity": "sha512-5pVLNK9wlpxTUTy9GpgbX/SdcRh+HBnPktjM2wbiLTH4p+2EPHBO1aoSryUCuKUIItdDWO9ITlhUL8UnUN/oIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react": "^0.26.16",
+        "@react-aria/focus": "^3.20.2",
+        "@react-aria/interactions": "^3.25.0",
+        "@tanstack/react-virtual": "^3.13.9",
+        "use-sync-external-store": "^1.5.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/@humanfs/core": {
@@ -915,6 +989,33 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@internationalized/date": {
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.12.1.tgz",
+      "integrity": "sha512-6IedsVWXyq4P9Tj+TxuU8WGWM70hYLl12nbYU8jkikVpa6WXapFazPUcHUMDMoWftIDE2ILDkFFte6W2nFCkRQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@internationalized/number": {
+      "version": "3.6.6",
+      "resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.6.6.tgz",
+      "integrity": "sha512-iFgmQaXHE0vytNfpLZWOC2mEJCBRzcUxt53Xf/yCXG93lRvqas237i3r7X4RKMwO3txiyZD4mQjKAByFv6UGSQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@internationalized/string": {
+      "version": "3.2.8",
+      "resolved": "https://registry.npmjs.org/@internationalized/string/-/string-3.2.8.tgz",
+      "integrity": "sha512-NdbMQUSfXLYIQol5VyMtinm9pZDciiMfN7RtmSuSB78io1hqwJ0naYfxyW6vgxWBkzWymQa/3uLDlbfmshtCaA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1148,6 +1249,44 @@
       "dev": true,
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@react-aria/focus": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.22.0.tgz",
+      "integrity": "sha512-ZfDOVuVhqDsM9mkNji3QUZ/d40JhlVgXrDkrfXylM1035QCrcTHN7m2DpbE95sU2A8EQb4wikvt5jM6K/73BPg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0",
+        "react-aria": "3.48.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/interactions": {
+      "version": "3.28.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/interactions/-/interactions-3.28.0.tgz",
+      "integrity": "sha512-OXwdU1EWFdMxmr/K1CXNGJzmNlCClByb+PuCaqUyzBymHPCGVhawirLIon/CrIN5psh3AiWpHSh4H0WeJdVpng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.34.0",
+        "@swc/helpers": "^0.5.0",
+        "react-aria": "3.48.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/shared": {
+      "version": "3.34.0",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.34.0.tgz",
+      "integrity": "sha512-gp6xo/s2lX54AlTjOiqwDnxA7UW79BNvI9dB9pr3LZTzRKCd1ZA+ZbgKw/ReIiWuvvVw/8QFJpnqeeFyLocMcQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@rtsao/scc": {
@@ -1418,6 +1557,33 @@
         "@tailwindcss/oxide": "4.2.2",
         "postcss": "^8.5.6",
         "tailwindcss": "4.2.2"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.13.24",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.24.tgz",
+      "integrity": "sha512-aIJvz5OSkhNIhZIpYivrxrPTKYsjW9Uzy+sP/mx0S3sev2HyvPb7xmjbYvokzEpfgYHy/HjzJ2zFAETuUfgCpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.14.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.14.0.tgz",
+      "integrity": "sha512-JLANqGy/D6k4Ujmh8Tr25lGimuOXNiaVyXaCAZS0W+1390sADdGnyUdSWNIfd49gebtIxGMij4IktRVzrdr12Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@tybys/wasm-util": {
@@ -2061,6 +2227,18 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
+    },
+    "node_modules/aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/aria-query": {
       "version": "5.3.2",
@@ -5080,6 +5258,27 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-aria": {
+      "version": "3.48.0",
+      "resolved": "https://registry.npmjs.org/react-aria/-/react-aria-3.48.0.tgz",
+      "integrity": "sha512-jQjd4rBEIMqecBaAKYJbVGK6EqIHLa5znVQ7jwFyK5vCyljoj6KhgtiahmcIPsG5vG5vEDLw+ba+bEWn6A2P4w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.12.1",
+        "@internationalized/number": "^3.6.6",
+        "@internationalized/string": "^3.2.8",
+        "@react-types/shared": "^3.34.0",
+        "@swc/helpers": "^0.5.0",
+        "aria-hidden": "^1.2.3",
+        "clsx": "^2.0.0",
+        "react-stately": "3.46.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
     "node_modules/react-dom": {
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
@@ -5096,6 +5295,23 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
+    },
+    "node_modules/react-stately": {
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/react-stately/-/react-stately-3.46.0.tgz",
+      "integrity": "sha512-OdxhWvHgs2L4OJGIs7hnuTr5WjjMM6enhNEAMRqiekhF8+ITvA2LRwNftOZwcogaoCslGYq5S2VQTQwnm0GbCA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.12.1",
+        "@internationalized/number": "^3.6.6",
+        "@internationalized/string": "^3.2.8",
+        "@react-types/shared": "^3.34.0",
+        "@swc/helpers": "^0.5.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -5675,6 +5891,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/tabbable": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
+      "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
+      "license": "MIT"
+    },
     "node_modules/tailwindcss": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
@@ -6009,6 +6231,15 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev -p 3001",
     "build": "next build",
     "start": "next start",
     "lint": "eslint"

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@headlessui/react": "^2.2.10",
     "clsx": "^2.1.1",
     "lucide-react": "^1.8.0",
     "next": "16.2.4",

--- a/stores/appStore.ts
+++ b/stores/appStore.ts
@@ -14,6 +14,7 @@ import type {
 
 const POOL_SIZE = 6;
 const BATTLE_SIZE = 3;
+const MOVESET_SIZE = 4;
 
 type DrawerTab = "strengths" | "weaknesses" | "coverage";
 
@@ -28,6 +29,7 @@ interface AppState extends PersistedSlice {
   oppPool: (Pokemon | null)[];
   myBattle: number[];
   oppBattle: number[];
+  myMovesets: (string | null)[][];
 
   pokemonCache: Map<string, PokemonData>;
   usageCache: Map<string, UsageData>;
@@ -45,6 +47,12 @@ interface AppState extends PersistedSlice {
   setSlot: (side: "my" | "opp", idx: number, mon: Pokemon | null) => void;
   clearSide: (side: "my" | "opp") => void;
   resetAll: () => void;
+  setMyMovesetMove: (
+    teamIdx: number,
+    moveIdx: number,
+    moveName: string | null,
+  ) => void;
+  clearMyMoveset: (teamIdx: number) => void;
 
   toggleBattle: (side: "my" | "opp", idx: number) => void;
   setBattle: (side: "my" | "opp", battle: number[]) => void;
@@ -67,6 +75,11 @@ interface AppState extends PersistedSlice {
 const emptyPool = (): (Pokemon | null)[] =>
   Array.from({ length: POOL_SIZE }, () => null);
 
+const emptyMovesets = (): (string | null)[][] =>
+  Array.from({ length: POOL_SIZE }, () =>
+    Array.from({ length: MOVESET_SIZE }, () => null),
+  );
+
 export const useAppStore = create<AppState>()(
   persist(
     (set, get) => ({
@@ -74,6 +87,7 @@ export const useAppStore = create<AppState>()(
       oppPool: emptyPool(),
       myBattle: [],
       oppBattle: [],
+      myMovesets: emptyMovesets(),
 
       pokemonCache: new Map(),
       usageCache: new Map(),
@@ -101,14 +115,30 @@ export const useAppStore = create<AppState>()(
         const battleKey = side === "my" ? "myBattle" : "oppBattle";
         const pool = [...get()[key]];
         pool[idx] = mon;
+        const patch: Partial<AppState> = {};
+        if (side === "my" && mon === null) {
+          patch.myMovesets = get().myMovesets.map((set, i) =>
+            i === idx ? Array.from({ length: MOVESET_SIZE }, () => null) : set,
+          );
+        }
         const battle = get()[battleKey].filter((i) => pool[i] !== null);
-        set({ [key]: pool, [battleKey]: battle } as unknown as Partial<AppState>);
+        set({
+          ...patch,
+          [key]: pool,
+          [battleKey]: battle,
+        } as unknown as Partial<AppState>);
       },
 
       clearSide: (side) => {
         const key = side === "my" ? "myPool" : "oppPool";
         const battleKey = side === "my" ? "myBattle" : "oppBattle";
-        set({ [key]: emptyPool(), [battleKey]: [] } as unknown as Partial<AppState>);
+        const patch: Partial<AppState> =
+          side === "my" ? { myMovesets: emptyMovesets() } : {};
+        set({
+          ...patch,
+          [key]: emptyPool(),
+          [battleKey]: [],
+        } as unknown as Partial<AppState>);
       },
 
       resetAll: () =>
@@ -117,9 +147,32 @@ export const useAppStore = create<AppState>()(
           oppPool: emptyPool(),
           myBattle: [],
           oppBattle: [],
+          myMovesets: emptyMovesets(),
           selectedSide: null,
           selectedSlot: null,
         }),
+
+      setMyMovesetMove: (teamIdx, moveIdx, moveName) => {
+        if (teamIdx < 0 || teamIdx >= POOL_SIZE) return;
+        if (moveIdx < 0 || moveIdx >= MOVESET_SIZE) return;
+        const myPool = get().myPool;
+        if (!myPool[teamIdx]) return;
+        const next = get().myMovesets.map((set, i) => {
+          if (i !== teamIdx) return set;
+          const updated = [...set];
+          updated[moveIdx] = moveName;
+          return updated;
+        });
+        set({ myMovesets: next });
+      },
+
+      clearMyMoveset: (teamIdx) => {
+        if (teamIdx < 0 || teamIdx >= POOL_SIZE) return;
+        const next = get().myMovesets.map((set, i) =>
+          i === teamIdx ? Array.from({ length: MOVESET_SIZE }, () => null) : set,
+        );
+        set({ myMovesets: next });
+      },
 
       toggleBattle: (side, idx) => {
         const battleKey = side === "my" ? "myBattle" : "oppBattle";
@@ -194,6 +247,7 @@ export const useAppStore = create<AppState>()(
               slug: p.slug,
               types: p.types,
               spriteUrl: p.spriteUrl,
+              moves: p.moves,
             };
         });
         const poolKey = into === "my" ? "myPool" : "oppPool";
@@ -201,7 +255,10 @@ export const useAppStore = create<AppState>()(
         const validBattle = (team.battleSelection ?? []).filter(
           (i) => pool[i] !== null,
         );
+        const patch: Partial<AppState> =
+          into === "my" ? { myMovesets: emptyMovesets() } : {};
         set({
+          ...patch,
           [poolKey]: pool,
           [battleKey]: validBattle,
         } as unknown as Partial<AppState>);


### PR DESCRIPTION
Added a searchable dropdown menu for pokemon move slots that alters the type chart accordingly. 

https://github.com/user-attachments/assets/4d82d9e2-6cc6-428e-acde-11f4c418375a

- only moves the pokemon learns
- ensures only damaging moves alter the type chart

